### PR TITLE
feat: add files from `:h 'exrc'` to default config

### DIFF
--- a/lua/config-local/init.lua
+++ b/lua/config-local/init.lua
@@ -6,7 +6,7 @@ local hashmap, notifier
 local M = {
   -- Default config
   config = {
-    config_files = { ".vimrc.lua", ".vimrc" },
+    config_files = { ".nvim.lua", ".nvimrc", ".exrc", ".vimrc.lua", ".vimrc" },
     hashfile = vim.fn.stdpath "data" .. "/config-local",
     autocommands_create = true,
     commands_create = true,


### PR DESCRIPTION
Note: Bulitin `'exrc'` [now has similar functionality](https://github.com/neovim/neovim/pull/20956) to this plugin. However, I still use `nvim-config-local` for the convenient autocmds.